### PR TITLE
feat: public landing board for unauthenticated users

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,7 +56,7 @@ initAuth(onAuth)
     │
     ├── Supabase not configured? → onAuth(null) immediately
     ├── getSession() → has session? → onAuth(user)
-    └── else → _renderSignIn() overlay (Google OAuth)
+    └── no session? → onAuth(null) (guest mode; no overlay; board loads)
     │
     ▼
 initBoardPicker(user)
@@ -72,7 +72,12 @@ initStorage(boardId)
     │
     ▼
 _hideLoading() → main()
+    │
+    └── If guest + Supabase enabled: add "Sign in" button (calls showSignIn()).
+        If authenticated: add "Sign out" button.
 ```
+
+Sign-in overlay is **not** shown on load when unauthenticated. It appears only when the user clicks "Sign in" in the UI. After OAuth redirect (or sign-out), the page reloads and bootstrap runs again with the new auth state.
 
 Error boundary: any uncaught exception in this chain shows a user-facing error card with a Reload button.
 
@@ -82,7 +87,7 @@ Error boundary: any uncaught exception in this chain shows a user-facing error c
 
 When `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are set, the app runs in **cloud mode**:
 
-- Auth overlay appears if no session; Google OAuth sign-in.
+- Root always shows a working board. If no session (guest), the board loads from localStorage and a "Sign in" button is shown; the auth overlay appears only when the user clicks it. After OAuth redirect, the page reloads and cloud boards load.
 - Board picker shows workspaces and boards; data syncs to Supabase.
 - `localStorage` is still written (optimistic) and used as offline fallback.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { initTheme, toggleTheme, getTheme, getDefaultStrokeColor } from './utils
 import { getSortedElements } from './state/selectors';
 import { copySelected, pasteClipboard } from './state/clipboard';
 import type { TextElement, StyleObject, DrawableElement, StrokeStyle, CornerStyle } from './types/elements';
-import { initAuth, signOut } from './auth/authGate';
+import { initAuth, showSignIn, signOut } from './auth/authGate';
 import { initBoardPicker } from './ui/boardPicker';
 import { SUPABASE_ENABLED } from './lib/supabase';
 
@@ -626,9 +626,10 @@ async function bootstrap(): Promise<void> {
         // Board picker resolves the active board ID (null in local mode)
         const boardId = await initBoardPicker(user);
 
-        // Wire sign-out button if we have an authenticated user
         if (SUPABASE_ENABLED && user) {
           _addSignOutButton();
+        } else if (SUPABASE_ENABLED) {
+          _addSignInButton();
         }
 
         // Init storage with the resolved board (loads canvas data)
@@ -678,7 +679,21 @@ function _showError(err: unknown): void {
   console.error('[bootstrap]', err);
 }
 
-// ── Sign-out button ────────────────────────────────────────
+// ── Sign-in / Sign-out buttons ────────────────────────────
+
+function _addSignInButton(): void {
+  if (document.getElementById('btn-signin')) return;
+
+  const btn = document.createElement('button');
+  btn.id = 'btn-signin';
+  btn.className = 'btn-signout';
+  btn.textContent = 'Sign in';
+  btn.title = 'Sign in to sync boards';
+  btn.addEventListener('click', () => showSignIn());
+
+  const actionsBar = document.getElementById('actions-bar');
+  if (actionsBar) actionsBar.appendChild(btn);
+}
 
 function _addSignOutButton(): void {
   if (document.getElementById('btn-signout')) return;


### PR DESCRIPTION
- Root always shows a functional board (guest or authenticated)
- Auth overlay only when user clicks Sign in
- Add showSignIn() and Sign in button for guests
- Reload only on OAuth callback (fix infinite reload loop)
- Update ARCHITECTURE.md and src/auth/ARCHITECTURE.md