### PR TITLE
fix: adjust zoom delta calculation for smoother zooming experience

### DIFF
--- a/src/canvas/EventHandler.ts
+++ b/src/canvas/EventHandler.ts
@@ -116,7 +116,7 @@ export class EventHandler {
     const { viewport } = getUIState();
 
     if (e.ctrlKey || e.metaKey) {
-      const delta = -e.deltaY * 0.01;
+      const delta = Math.max(-0.05, Math.min(0.05, -e.deltaY * 0.003));
       const newZoom = Math.max(0.05, Math.min(20, viewport.zoom * (1 + delta)));
       const rect = this.canvas.getBoundingClientRect();
       setViewport(zoomOnPoint(viewport, e.clientX - rect.left, e.clientY - rect.top, newZoom));


### PR DESCRIPTION
- Updated the zoom delta calculation to limit the zoom change to a maximum of 0.05, ensuring a more controlled and smoother zooming experience when using the mouse wheel.